### PR TITLE
Build strict Sygmare orchestration app

### DIFF
--- a/sygmare_app/__init__.py
+++ b/sygmare_app/__init__.py
@@ -1,0 +1,17 @@
+"""Sygmare orchestration package for the Aurvo ecosystem."""
+
+from .models import BuildError, BuildKind, BuildRecord, Component, Manifest, QualitySpec
+from .orchestrator import Orchestrator, OrchestratorConfig
+from .statuses import BuildStatus
+
+__all__ = [
+    "BuildError",
+    "BuildKind",
+    "BuildRecord",
+    "BuildStatus",
+    "Component",
+    "Manifest",
+    "QualitySpec",
+    "Orchestrator",
+    "OrchestratorConfig",
+]

--- a/sygmare_app/cli.py
+++ b/sygmare_app/cli.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from pathlib import Path
+from typing import Iterable, Optional
+
+from .manifest import ManifestLoader
+from .models import BuildError
+from .orchestrator import Orchestrator, OrchestratorConfig
+from .planner import StrictPlanner
+from .statuses import BuildStatus
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Aplicación Sygmare para hiperorquestación sintética del ecosistema AURVO."
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path("sygmare_manifest.json"),
+        help="Ruta al manifiesto JSON que describe los componentes a compilar.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Muestra las acciones sin ejecutarlas.",
+    )
+    parser.add_argument(
+        "--stop-on-failure",
+        action="store_true",
+        help="Detiene la orquestación en el primer fallo de compilación o de calidad.",
+    )
+    return parser
+
+
+def run_cli(argv: Optional[Iterable[str]] = None) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    repo_root = Path(__file__).resolve().parent.parent
+    loader = ManifestLoader(repo_root)
+
+    try:
+        manifest = loader.load(args.manifest)
+    except Exception as exc:  # noqa: BLE001
+        parser.error(str(exc))
+
+    planner = StrictPlanner(manifest)
+    try:
+        plan = planner.plan()
+    except BuildError as exc:
+        parser.error(str(exc))
+
+    orchestrator = Orchestrator(
+        OrchestratorConfig(dry_run=args.dry_run, stop_on_failure=args.stop_on_failure)
+    )
+
+    try:
+        records = orchestrator.build(plan)
+    except BuildError as exc:
+        print(f"✖ {exc}")
+        return 1
+
+    counts = Counter(record.status for record in records)
+
+    print("Resumen:")
+    for record in records:
+        print(f"  - {record.component.name}: {record.status}")
+        if record.details:
+            print(f"      {record.details}")
+
+    print("\nTotales:")
+    for status in BuildStatus:
+        print(f"  {status.value:>14}: {counts.get(status.value, 0)}")
+
+    failures = counts.get(BuildStatus.FAILED.value, 0)
+    quality_failures = counts.get(BuildStatus.QUALITY_FAILED.value, 0)
+    return 0 if failures == 0 and quality_failures == 0 else 1
+
+
+__all__ = ["build_argument_parser", "run_cli"]

--- a/sygmare_app/executors.py
+++ b/sygmare_app/executors.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from .models import BuildKind, Component
+from .statuses import BuildStatus
+
+
+@dataclass
+class CommandResult:
+    status: BuildStatus
+    details: Optional[str] = None
+
+
+def command_exists(command: str) -> bool:
+    return shutil.which(command) is not None
+
+
+def shlex_quote(arg: str) -> str:
+    if not arg:
+        return "''"
+    if all(ch.isalnum() or ch in "@%_=+,-./" for ch in arg):
+        return arg
+    return "'" + arg.replace("'", "'\\''") + "'"
+
+
+def readable_cmd(cmd: Iterable[str]) -> str:
+    return " ".join(shlex_quote(part) for part in cmd)
+
+
+def run_command(cmd: List[str], *, cwd: Optional[Path], dry_run: bool) -> subprocess.CompletedProcess:
+    display_cwd = f" (cwd={cwd})" if cwd else ""
+    print(f"    → {readable_cmd(cmd)}{display_cwd}")
+    if dry_run:
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    result = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    if result.stdout:
+        for line in result.stdout.splitlines():
+            print(f"      {line}")
+    if result.returncode != 0:
+        print(f"      ✖ Command exited with code {result.returncode}")
+    return result
+
+
+class PythonBuilder:
+    def build(self, component: Component, *, dry_run: bool) -> CommandResult:
+        if not component.path.exists():
+            message = f"Directorio {component.path} no encontrado."
+            print(f"  ⚠️  {component.name}: {message}")
+            return CommandResult(BuildStatus.MISSING, message)
+
+        python_files = list(component.path.rglob("*.py"))
+        if not python_files:
+            message = "No se encontraron archivos Python para compilar."
+            print(f"  ⚠️  {component.name}: {message}")
+            return CommandResult(BuildStatus.SKIPPED, message)
+
+        result = run_command([sys.executable, "-m", "compileall", str(component.path)], cwd=None, dry_run=dry_run)
+        status = BuildStatus.BUILT if result.returncode == 0 else BuildStatus.FAILED
+        return CommandResult(status)
+
+
+class NodeBuilder:
+    def build(self, component: Component, *, dry_run: bool) -> CommandResult:
+        package_json = component.path / "package.json"
+        if not component.path.exists() or not package_json.exists():
+            message = f"package.json no encontrado en {component.path}"
+            print(f"  ⚠️  {component.name}: {message}")
+            return CommandResult(BuildStatus.MISSING, message)
+
+        if not command_exists("npm"):
+            message = "npm no está instalado en este entorno."
+            print(f"  ⚠️  {component.name}: {message}")
+            return CommandResult(BuildStatus.SKIPPED, message)
+
+        commands = component.normalized_commands() or [["npm", "install"], ["npm", "run", "build"]]
+        status = BuildStatus.BUILT
+        for cmd in commands:
+            result = run_command(cmd, cwd=component.path, dry_run=dry_run)
+            if result.returncode != 0:
+                status = BuildStatus.FAILED
+                break
+        return CommandResult(status)
+
+
+class ShellBuilder:
+    def build(self, component: Component, *, dry_run: bool) -> CommandResult:
+        if not component.path.exists():
+            message = f"script {component.path} no encontrado"
+            print(f"  ⚠️  {component.name}: {message}")
+            return CommandResult(BuildStatus.MISSING, message)
+
+        if not component.path.is_file():
+            message = f"Se esperaba un archivo ejecutable y se encontró {component.path}."
+            print(f"  ⚠️  {component.name}: {message}")
+            return CommandResult(BuildStatus.FAILED, message)
+
+        if not dry_run:
+            current_mode = component.path.stat().st_mode
+            component.path.chmod(current_mode | 0o111)
+
+        if command_exists("shellcheck"):
+            result = run_command(["shellcheck", str(component.path)], cwd=None, dry_run=dry_run)
+            if result.returncode != 0:
+                return CommandResult(BuildStatus.FAILED, "shellcheck falló")
+
+        for cmd in component.normalized_commands():
+            result = run_command(cmd, cwd=component.path.parent, dry_run=dry_run)
+            if result.returncode != 0:
+                return CommandResult(BuildStatus.FAILED)
+
+        return CommandResult(BuildStatus.BUILT)
+
+
+def builder_registry() -> Dict[BuildKind, object]:
+    return {
+        BuildKind.PYTHON: PythonBuilder(),
+        BuildKind.NODE: NodeBuilder(),
+        BuildKind.SHELL: ShellBuilder(),
+    }
+
+
+__all__ = [
+    "CommandResult",
+    "PythonBuilder",
+    "NodeBuilder",
+    "ShellBuilder",
+    "builder_registry",
+    "command_exists",
+    "run_command",
+]

--- a/sygmare_app/manifest.py
+++ b/sygmare_app/manifest.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .models import BuildKind, Component, Manifest, QualitySpec
+
+
+class ManifestLoader:
+    def __init__(self, repo_root: Path) -> None:
+        self._repo_root = repo_root
+
+    def load(self, manifest_path: Path | None) -> Manifest:
+        if manifest_path and manifest_path.exists():
+            data = json.loads(manifest_path.read_text())
+            components = [self._from_dict(item, manifest_path.parent) for item in data]
+            return Manifest(components)
+        return self.default_manifest()
+
+    def default_manifest(self) -> Manifest:
+        root = self._repo_root
+        components = [
+            Component(
+                name="AURVO Core",
+                path=root / "AURVO_OS" / "core",
+                kind=BuildKind.PYTHON,
+                quality=QualitySpec(required_paths=("__init__.py",)),
+            ),
+            Component(
+                name="Hiperorquestación Cognitiva",
+                path=root / "AURVO_OS" / "hoc",
+                kind=BuildKind.PYTHON,
+                quality=QualitySpec(required_paths=("__init__.py",)),
+            ),
+            Component(
+                name="SantoSecure",
+                path=root / "AURVO_OS" / "security",
+                kind=BuildKind.PYTHON,
+                quality=QualitySpec(required_paths=("__init__.py",)),
+            ),
+            Component(
+                name="Aurvo AI",
+                path=root / "AURVO_OS" / "ai",
+                kind=BuildKind.PYTHON,
+                quality=QualitySpec(required_paths=("__init__.py",)),
+            ),
+            Component(
+                name="Aurvo Dashboard",
+                path=root / "AURVO_OS" / "ui",
+                kind=BuildKind.NODE,
+                quality=QualitySpec(forbid_empty=True),
+            ),
+            Component(
+                name="Maestro bootstrap",
+                path=root / "aurvo OS código ",
+                kind=BuildKind.SHELL,
+                quality=QualitySpec(forbid_empty=True),
+            ),
+        ]
+        return Manifest(components)
+
+    def _from_dict(self, item: dict, base: Path) -> Component:
+        path = item.get("path")
+        if not path:
+            raise ValueError("Cada componente necesita un campo 'path'.")
+
+        commands = item.get("commands") or []
+        dependencies = item.get("dependencies") or []
+        kind = BuildKind(item.get("kind", "python"))
+
+        quality_spec = None
+        quality_data = item.get("quality")
+        if quality_data is not None:
+            quality_spec = QualitySpec(
+                required_paths=tuple(quality_data.get("required_paths", ())),
+                forbid_empty=quality_data.get("forbid_empty", True),
+                description=quality_data.get("description"),
+            )
+
+        return Component(
+            name=item["name"],
+            path=(base / path) if not Path(path).is_absolute() else Path(path),
+            kind=kind,
+            build_commands=tuple(tuple(cmd) for cmd in commands),
+            dependencies=tuple(dependencies),
+            quality=quality_spec,
+        )
+
+
+__all__ = ["ManifestLoader"]

--- a/sygmare_app/models.py
+++ b/sygmare_app/models.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+
+class BuildKind(str, Enum):
+    """Canonical build kinds supported by the orchestration engine."""
+
+    PYTHON = "python"
+    NODE = "node"
+    SHELL = "shell"
+
+
+@dataclass(frozen=True)
+class QualitySpec:
+    """Declarative description of quality gates for a component."""
+
+    required_paths: Sequence[str] = ()
+    forbid_empty: bool = True
+    description: Optional[str] = None
+
+    def materialized_paths(self, base_path: Path) -> List[Path]:
+        return [base_path / rel for rel in self.required_paths]
+
+
+@dataclass(frozen=True)
+class Component:
+    """Represents a buildable unit in the ecosystem."""
+
+    name: str
+    path: Path
+    kind: BuildKind
+    build_commands: Sequence[Sequence[str]] = ()
+    dependencies: Sequence[str] = ()
+    quality: Optional[QualitySpec] = None
+
+    def normalized_commands(self) -> List[List[str]]:
+        return [list(cmd) for cmd in self.build_commands]
+
+
+@dataclass(frozen=True)
+class Manifest:
+    components: Sequence[Component] = field(default_factory=list)
+
+    def by_name(self) -> dict[str, Component]:
+        return {component.name: component for component in self.components}
+
+
+@dataclass(frozen=True)
+class BuildRecord:
+    component: Component
+    status: str
+    details: Optional[str] = None
+
+
+class BuildError(RuntimeError):
+    pass

--- a/sygmare_app/orchestrator.py
+++ b/sygmare_app/orchestrator.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from .executors import CommandResult, builder_registry
+from .models import BuildError, BuildRecord, Component
+from .quality import StrictQualityInspector
+from .statuses import BuildStatus
+
+
+@dataclass
+class OrchestratorConfig:
+    dry_run: bool = False
+    stop_on_failure: bool = False
+
+
+class Orchestrator:
+    def __init__(self, config: OrchestratorConfig | None = None) -> None:
+        self.config = config or OrchestratorConfig()
+        self._quality = StrictQualityInspector()
+        self._builders = builder_registry()
+
+    def build(self, components: Iterable[Component]) -> List[BuildRecord]:
+        records: List[BuildRecord] = []
+        for component in components:
+            print(f"▶ {component.name}")
+            report = self._quality.evaluate(component)
+            if not report.passed:
+                details = report.formatted()
+                print("  ✖ Calidad no superada:")
+                for line in details.splitlines():
+                    print(f"    {line}")
+                records.append(BuildRecord(component, BuildStatus.QUALITY_FAILED.value, details))
+                if self.config.stop_on_failure:
+                    raise BuildError(f"Calidad fallida para {component.name}")
+                print()
+                continue
+
+            builder = self._builders.get(component.kind)
+            if builder is None:
+                message = f"Tipo de componente no soportado: {component.kind}"
+                print(f"  ⚠️  {message}")
+                records.append(BuildRecord(component, BuildStatus.SKIPPED.value, message))
+                print()
+                continue
+
+            result: CommandResult = builder.build(component, dry_run=self.config.dry_run)
+            records.append(BuildRecord(component, result.status.value, result.details))
+            print(f"  → Resultado: {result.status.value}\n")
+
+            if result.status == BuildStatus.FAILED and self.config.stop_on_failure:
+                raise BuildError(f"Fallo de compilación en {component.name}")
+
+        return records
+
+
+__all__ = ["Orchestrator", "OrchestratorConfig"]

--- a/sygmare_app/planner.py
+++ b/sygmare_app/planner.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from graphlib import CycleError, TopologicalSorter
+
+from .models import BuildError, Component, Manifest
+
+
+class StrictPlanner:
+    """Determines the build order using strict dependency validation."""
+
+    def __init__(self, manifest: Manifest) -> None:
+        self._manifest = manifest
+
+    def plan(self) -> list[Component]:
+        name_map = self._manifest.by_name()
+        sorter = TopologicalSorter()
+
+        for component in self._manifest.components:
+            missing = [dep for dep in component.dependencies if dep not in name_map]
+            if missing:
+                raise BuildError(
+                    f"Dependencias desconocidas para {component.name}: {', '.join(missing)}"
+                )
+            sorter.add(component.name, *component.dependencies)
+
+        try:
+            ordered_names = list(sorter.static_order())
+        except CycleError as exc:
+            raise BuildError(f"Dependencias circulares detectadas: {exc}") from exc
+
+        return [name_map[name] for name in ordered_names if name in name_map]
+
+
+__all__ = ["StrictPlanner"]

--- a/sygmare_app/quality.py
+++ b/sygmare_app/quality.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from .models import BuildKind, Component
+
+
+@dataclass
+class QualityFinding:
+    level: str
+    message: str
+
+
+@dataclass
+class QualityReport:
+    component: Component
+    findings: List[QualityFinding] = field(default_factory=list)
+
+    def add_error(self, message: str) -> None:
+        self.findings.append(QualityFinding("error", message))
+
+    def add_warning(self, message: str) -> None:
+        self.findings.append(QualityFinding("warning", message))
+
+    @property
+    def passed(self) -> bool:
+        return all(f.level != "error" for f in self.findings)
+
+    def formatted(self) -> str:
+        if not self.findings:
+            return "OK"
+        return "\n".join(f"[{f.level.upper()}] {f.message}" for f in self.findings)
+
+
+class StrictQualityInspector:
+    """Strict validation stage prior to orchestration."""
+
+    def evaluate(self, component: Component) -> QualityReport:
+        report = QualityReport(component)
+        path = component.path
+
+        if not path.exists():
+            report.add_error(f"La ruta {path} no existe.")
+            return report
+
+        if component.kind == BuildKind.PYTHON:
+            python_files = list(path.rglob("*.py"))
+            if not python_files:
+                report.add_error("No se detectaron archivos Python.")
+        elif component.kind == BuildKind.NODE:
+            package_json = path / "package.json"
+            if not package_json.exists():
+                report.add_error("Falta package.json para construir el proyecto Node.")
+        elif component.kind == BuildKind.SHELL:
+            if not path.is_file():
+                report.add_error("El componente shell debe apuntar a un archivo ejecutable.")
+            elif path.stat().st_size == 0:
+                report.add_error("El script shell está vacío.")
+
+        spec = component.quality
+        if spec:
+            for required in spec.materialized_paths(path):
+                if not required.exists():
+                    report.add_error(f"Falta recurso requerido: {required}.")
+            if spec.forbid_empty and component.kind != BuildKind.SHELL:
+                if path.is_dir() and not any(path.iterdir()):
+                    report.add_error("El directorio del componente está vacío.")
+
+        return report
+
+
+__all__ = [
+    "QualityFinding",
+    "QualityReport",
+    "StrictQualityInspector",
+]

--- a/sygmare_app/statuses.py
+++ b/sygmare_app/statuses.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class BuildStatus(str, Enum):
+    BUILT = "built"
+    SKIPPED = "skipped"
+    MISSING = "missing"
+    FAILED = "failed"
+    QUALITY_FAILED = "quality_failed"
+
+
+__all__ = ["BuildStatus"]

--- a/sygmare_compile.py
+++ b/sygmare_compile.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Aplicación de hiperorquestación sintética Sygmare para AURVO.
+
+Este módulo actúa como *entrypoint* de la aplicación estricta diseñada para
+coordinar compilaciones, verificaciones de calidad y dependencias entre todos
+los componentes del ecosistema.  Internamente delega en ``sygmare_app`` que
+implementa algoritmos rigurosos de planificación topológica, controles de
+calidad y ejecución resiliente de comandos.
+"""
+
+from __future__ import annotations
+
+from sygmare_app.cli import run_cli
+
+
+def main() -> int:
+    return run_cli()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- introduce a dedicated `sygmare_app` package with models, manifest loader, strict planner, quality gates, and builders for python/node/shell components
- replace the previous script logic with a CLI that orchestrates builds through rigorous validation and dependency handling
- keep `sygmare_compile.py` as a thin entrypoint that invokes the new application

## Testing
- python sygmare_compile.py --dry-run *(fails: repository is missing the strict default component directories, which the new quality gates correctly flag)*

------
https://chatgpt.com/codex/tasks/task_e_68faf40d82a4832eb7df756ea7a10cb0